### PR TITLE
Disable security component when it's active

### DIFF
--- a/Controller/OpauthController.php
+++ b/Controller/OpauthController.php
@@ -6,5 +6,11 @@ class OpauthController extends OpauthAppController {
 		if (is_object($this->Auth) && method_exists($this->Auth, 'allow')) {
 			$this->Auth->allow();
 		}
+
+		//Disable Security for the plugin actions in case that Security Component is active
+		if (is_object($this->Security)) {
+			$this->Security->validatePost = false;
+			$this->Security->csrfCheck = false;	
+		}
 	}
 }


### PR DESCRIPTION
As we receive postback from 3rd authentication providers we have to disable the security plugin in case that app is using the component
