### PR TITLE
Handle 3rd-party plugins that expect a modelClass for all controllers

### DIFF
--- a/Controller/OpauthController.php
+++ b/Controller/OpauthController.php
@@ -1,6 +1,11 @@
 <?php
 class OpauthController extends OpauthAppController {
 
+	public function __construct($request = null, $response = null) {
+		parent::__construct($request, $response);
+		$this->modelClass = null;
+	}
+
 	public function beforeFilter() {
 		// Allow access to Opauth methods for users of AuthComponent
 		if (is_object($this->Auth) && method_exists($this->Auth, 'allow')) {


### PR DESCRIPTION
The CRUD controller currently expects this sort of authentication logic to exist within a Controller, not a plugin Controller that has no models. Forcing `$this->modelClass = null` in the `__construct()` is the only way to do this.
