### PR TITLE
Update .gitmodules - opauth submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendor/Opauth"]
 	path = Vendor/Opauth
-	url = https://github.com/opauth/opauth.git
+	url = git://github.com/opauth/opauth.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendor/Opauth"]
 	path = Vendor/Opauth
-	url = git://github.com/opauth/opauth.git
+	url = https://github.com/opauth/opauth.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendor/Opauth"]
 	path = Vendor/Opauth
-	url = git://github.com/uzyn/opauth.git
+	url = git://github.com/opauth/opauth.git


### PR DESCRIPTION
Because the repo moved from https://github.com/uzyn/opauth to https://github.com/opauth/opauth
Maybe its better to update the submodule in this git repo - pointing to the right opauth repo?
Took me a while to notice the `lib` folder is empty.

Updated submodule Vendor/Opauth to match new repo opauth/opauth
