### PR TITLE
custom AuthComponent class support added

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -81,3 +81,10 @@ Configure::write('Opauth.strategy_dir', dirname(dirname(__FILE__)).'/Strategy/')
  *
  */
 Configure::write('Opauth.Strategy', array());
+
+/**
+ * AuthComponent Class Name
+ * Use to allow access to Opauth methods for users of AuthComponent
+ * eg. for Auth $this->Auth->allow() is used
+ */
+Configure::write('Opauth.AuthComponent','Auth');

--- a/Controller/OpauthController.php
+++ b/Controller/OpauthController.php
@@ -3,8 +3,9 @@ class OpauthController extends OpauthAppController {
 
 	public function beforeFilter() {
 		// Allow access to Opauth methods for users of AuthComponent
-		if (is_object($this->Auth) && method_exists($this->Auth, 'allow')) {
-			$this->Auth->allow();
+		$Auth = Configure::read('Opauth.AuthComponent');
+		if ($Auth && is_object($this->{$Auth}) && method_exists($this->{$Auth}, 'allow')) {
+			$this->{$Auth}->allow();
 		}
 
 		//Disable Security for the plugin actions in case that Security Component is active


### PR DESCRIPTION
With this the user can override Configure::Opauth['AuthComponent'] for their own custom AuthComponent Class.

eg :-  If user want to make his own AuthComponent class like

  class MyAuthComponent extends AuthComponent{

  }

then in his bootstrap file he can write 
CakePlugin::load('Opauth', array('routes' => true, 'bootstrap' => true));
Configure::write('Opauth.AuthComponent','MyAuth') ;
and OpauthController will be allowed by MyAuth
